### PR TITLE
Update Reaper to 5.973

### DIFF
--- a/reaper/reaper.nuspec
+++ b/reaper/reaper.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>reaper</id>
     <title>Reaper</title>
-    <version>5.971</version>
+    <version>5.973</version>
     <authors>Cockos Incorporated</authors>
     <owners>Olivier Martin</owners>
     <summary>Reaper Digital Audio Workstation</summary>

--- a/reaper/tools/chocolateyinstall.ps1
+++ b/reaper/tools/chocolateyinstall.ps1
@@ -3,10 +3,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'reaper'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url32      = 'http://dlcf.reaper.fm/5.x/reaper5971-install.exe'
-$checksum32 = '0a3f3385928eb8e85552dc5dd846e514e515cc5f2028e5e1609c9f871348f0ca'
-$url64      = 'http://dlcf.reaper.fm/5.x/reaper5971_x64-install.exe'
-$checksum64 = '23cd758407c3d361910ec2c80fa95d6da3579c0f7e1bf6abe144decc98d83409'
+$url32      = 'http://dlcf.reaper.fm/5.x/reaper5973-install.exe'
+$checksum32 = 'ab6872b4f271c656a7c76c72fc5ffac1cc2aa6d23a8af4aff4bcc9c21713dfd3'
+$url64      = 'http://dlcf.reaper.fm/5.x/reaper5973_x64-install.exe'
+$checksum64 = 'eb2af16cedddef5e5441319293c29bbed3076147bae2e145ca4ef84d9067de30'
 
 $packageArgs = @{
   packageName   = $packageName


### PR DESCRIPTION
Fixes #2 

### Changelog


5.973

    Audio Units: fix plug-in compatibility issue in 5.97 •
    Audio Units: report recording state if requested
    Continuous scrolling: improve item button hit testing
    Folder tracks: correctly detect some feedback situations with nested folders •
    IDEs: do not blink edit cursor when editor lacks focus
    JSFX: fix potential crash when loading .wav files •
    Marquee zoom: fix issues with tracks that have locked height •
    Media explorer: fix seeking of media when 'Start on bar' is set •
    Normalization: improve gain calculation behavior with high bit depth media •
    Performance: fix UI lag introduced in 5.972 •
    Project bay: fix up column left/right/center justification •
    ReaScript: fix TrackEnvelope validation •
    Render: properly update tail button when opening render dialog
    Takes: added actions to cycle to next/previous takes (pre-5.965 behavior) • 

5.972

    ARA: add FX menu action to align media to detected grid
    ARA: improve interaction of FX menu items to import notes, tempo, and time signatures
    ARA: remove menu actions to export tempo and notes and MIDI (instead, import to the project and then export if needed)
    ARA: set minimal undo state saving by default for Melodyne
    ARA: support linear tempo transitions
    Actions: fix action to create measure from time selection when there is an existing tempo marker at the end of the selection •
    Free item positioning: create a blank lane if there are no existing overlapping media items when enabling free item positioning
    Free item positioning: more parsimonious vertical spacing with multiple overlapping items
    Media explorer: fix measure-aligned tempo sync dropouts
    Notation editor: fix PDF export when using percussion clef •
    ReaScript: add get_config_var_string()
    Render: support rendering only selected regions in an existing region render matrix •
    Routing/grouping/render matrix: hide children of compacted folder tracks
    Routing/grouping/render matrix: show track and region colors
    Theming: add [track|mcp]_recarm_[auto_]norec images
    Theming: add color blend/alpha for grid lines, MIDI editor grid lines
    Theming: add color configuration for CC lane add/remove buttons
    Theming: add color configuration item for MIDI piano pane background
    Theming: add theme items for MIDI editor CC horizontal lines
    Theming: improve text contrast colors
    Theming: support complex rules for mcp.size and mcp.master.size
    Theming: obey meter text colors alpha field (0-255) if theme version is 6 or higher
    Transport: auto-arrange rate label/field if less than 2:1 aspect ratio 

### Testing
Locally did:
```
choco pack .
choco upgrade -s . reaper
```