### PR TITLE
Update Reaper to 5.975

### DIFF
--- a/reaper/reaper.nuspec
+++ b/reaper/reaper.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>reaper</id>
     <title>Reaper</title>
-    <version>5.974</version>
+    <version>5.975</version>
     <authors>Cockos Incorporated</authors>
     <owners>Olivier Martin</owners>
     <summary>Reaper Digital Audio Workstation</summary>

--- a/reaper/tools/chocolateyinstall.ps1
+++ b/reaper/tools/chocolateyinstall.ps1
@@ -3,10 +3,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'reaper'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url32      = 'http://dlcf.reaper.fm/5.x/reaper5974-install.exe'
-$checksum32 = 'c94f75386db16425581a52a4ce2481cea4660c63f2b8749de65513e784e13b6e'
-$url64      = 'http://dlcf.reaper.fm/5.x/reaper5974_x64-install.exe'
-$checksum64 = '8c3d5e7aec1eeb15589778251869dc786f62e4bdcae71a5122b0c996f3726db3'
+$url32      = 'http://dlcf.reaper.fm/5.x/reaper5975-install.exe'
+$checksum32 = 'ba58bd4481f58acfad1da0d240f5216555efa71f9368a9eb85b1883e2d1890bd'
+$url64      = 'http://dlcf.reaper.fm/5.x/reaper5975_x64-install.exe'
+$checksum64 = '060fab18429c62ae9b9acd63687d0a8b8a1122afbfb3115f4d852e90c9a027ce'
 
 $packageArgs = @{
   packageName   = $packageName


### PR DESCRIPTION
v5.975 - April 30 2019
  + API: safer <EXTSTATE encoding of long ascii strings, more efficient encoding of shorter UTF-8 strings
  + ARA: fix potential crash on closing REAPER
  + ARA: fix potential crash when moving media from one ARA track to another [t=219699]
  + ARA: improve loading projects when source files were moved or renamed
  + Actions: fix action to set item start to source media start with negative start offset [p=2118376]
  + Actions: improve Apply FX/Render Item speed when processing large numbers of files
  + Actions: auto-build peaks when pasting if pasted chunk has WANT_PEAKS_BUILD 1 token at top level
  + Audio: prevent race condition where audio device could be left in a closed state when loading a project that changes audio device samplerate [t=219984]
  + Automation items: apply AIs when applying pan/width via VCA
  + Automation items: apply AIs when calculating video processor mute/wet values
  + Automation items: apply AIs when linking track volume/pan to MIDI channels [p=2123953]
  + Automation items: update edge attachment when loading automation item from disk
  + Elastique: update to v3.3.0
  + FX: improve performance while stopped when using large numbers of automated parameters [t=219231]
  + FX: improve live FX multiprocessing scheduling with complex routing
  + FX: optimize automated parameter control surface notifications
  + MIDI: add action to remove duplicate selected events (existing action only removed duplicate notes)
  + MIDI: send MIDI CCs to parent/sends when track has MIDI controls enabled but no media nor FX
  + MIDI: more efficient import of .mid files with many duplicate events [t=219351]
  + Media explorer: import automation item name when inserting via media explorer action
  + Media explorer: support drag-import of multiple automation items at once
  + NINJAM: crosslap .ogg files when concatenating to .wav files from imported clipsort.log
  + NINJAM: improve subsample accounting when importing clipsort.log
  + NINJAM: fix ReaNINJAM writing of stereo .wav files of local streams [p=2124239]
  + NINJAM: improve ReaNINJAM sound quality at end of each interval
  + Notation: duplicate articulations when duplicating notes up/down an octave [t=220147]
  + Notation: fix musicxml export issues with multiple voices
  + Notation: improve display of tied voiced notes
  + Notation: improve proportional spacing display [t=219655]
  + Notation: split long beams more predictably [p=2125451]
  + OSC: fix incorrect saving of action bindings for non-main sections
  + Project bay: add support for automation items
  + Project bay: optimize copy/move of large numbers of files
  + Project help: report correct time since last manual project save [t=219875]
  + Project save: optimize copying of project media files [t=216526]
  + Projects: losslessly encode long/complex track/take/marker/region names in project/undo state [p=2120673]
  + ReaScript: add GetSetAutomationItemInfo(D_POOL_QNLEN), MIDIEditor_SetSetting_Int()
  + ReaScript: add GetSetProjectInfo_String(RENDER_FORMAT), GetItemFromPoint(), GetTrackFromPoint()
  + ReaScript: add P_EXT: prefix for extension-specific string state for GetSetMediaTrackInfo_String(), GetSetAutomationItemInfo_String(), etc
  + ReaScript: add GetSetTrackSendInfo_String() and GetSetEnvelopeInfo_String() (for P_EXT: use)
  + ReaScript: allow using various GetSet..Value() functions with strings, automatically converting numbers to/from string
  + ReaScript: update to Lua 5.3.5
  + Render: allow dither and noise shaping when rendering stems
  + Render: fix potentially incorrect region time wildcards [t=213312]
  + Ruler: display selected regions (for rendering) more distinctly
  + Ruler: add context menu item to render individual regions
  + Snap: add option to snap time selection to media item edges [t=218957]
  + Take FX: add actions to set take FX on/offline [t=220052]
  + Take FX: update FX window titles when duplicating take via action
  + Take FX: flush all take FX on playback start
  + Theming: add new HSV blend mode with bugfixes, old behavior is now deprecated HSV adjust blend mode
  + UI: improve mute/solo swipe behavior when there are hidden grouped tracks [t=219783]
  + UI: improve multimonitor tooltip behavior
  + UI: improve take envelope button drag/click behaviors
  + VST: automatically default to VST3 soft reset for plug-ins that appear to support setProcessing
  + VST: prevent hard reset from called from audio thread when flushing buffers
  + linux: improve keyboard handling with modal window open
  + linux: install SIGPIPE handler
  + macOS: prevent network related SIGPIPE crashes