### PR TITLE
Update Reaper to 5.976

### DIFF
--- a/reaper/reaper.nuspec
+++ b/reaper/reaper.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>reaper</id>
     <title>Reaper</title>
-    <version>5.975</version>
+    <version>5.976</version>
     <authors>Cockos Incorporated</authors>
     <owners>Olivier Martin</owners>
     <summary>Reaper Digital Audio Workstation</summary>

--- a/reaper/tools/chocolateyinstall.ps1
+++ b/reaper/tools/chocolateyinstall.ps1
@@ -3,10 +3,10 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'reaper'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url32      = 'http://dlcf.reaper.fm/5.x/reaper5975-install.exe'
-$checksum32 = 'ba58bd4481f58acfad1da0d240f5216555efa71f9368a9eb85b1883e2d1890bd'
-$url64      = 'http://dlcf.reaper.fm/5.x/reaper5975_x64-install.exe'
-$checksum64 = '060fab18429c62ae9b9acd63687d0a8b8a1122afbfb3115f4d852e90c9a027ce'
+$url32      = 'http://dlcf.reaper.fm/5.x/reaper5976-install.exe'
+$checksum32 = 'b66313b3895f881ecc73c74040ba1f5f7a59f0e9d622bb9eaf3d302d05e30302'
+$url64      = 'http://dlcf.reaper.fm/5.x/reaper5976_x64-install.exe'
+$checksum64 = '00838643939714909f4ec1dd229701e01b4410b06fe262e49f9c3c8f73fcd6b3'
 
 $packageArgs = @{
   packageName   = $packageName


### PR DESCRIPTION
(Still sending a pull request, got a 403 Forbidden trying to push this change directly into this repo.)

v5.976 - May 3 2019
  + Automation items: copying AIs copies extension state [p=2128744]
  + Envelopes: fix default bezier tension when adding automation item to otherwise empty envelope [t=220432]
  + MIDI: fix diamonds/triangles peak view for very low numbered MIDI notes [t=220319]
  + Media explorer: improve performance with large databases [t=220351]
  + Mousewheel: add undo points when changing track volume/pan/width via mousewheel [t=190260]
  + Project bay: always display position/length in time for time-based media, beats for beat-based media
  + ReaScript: SetEnvelopeStateChunk() updates envelope panels [t=220308]
  + Stability: fix potential crash when renaming tracks and SWS auto-layout is used [t=220400]
  + Stability: fix project bay automation item-related crash [p=2128917]
  + Stretch markers: permit adding markers on audioless video items [t=220352]
  + Transport: improve jump to marker/region menu [t=220350]