### PR TITLE
Reaper 7.36

### DIFF
--- a/reaper/reaper.nuspec
+++ b/reaper/reaper.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>reaper</id>
     <title>Reaper</title>
-    <version>7.35.0</version>
+    <version>7.36.0</version>
     <authors>Cockos Incorporated</authors>
     <owners>Olivier Martin, Bradlee Speice, Jerome Benoit</owners>
     <summary>Reaper Digital Audio Workstation</summary>

--- a/reaper/tools/chocolateyinstall.ps1
+++ b/reaper/tools/chocolateyinstall.ps1
@@ -2,10 +2,10 @@
 $ErrorActionPreference = 'Stop';
 
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url32 = 'https://reaper.fm/files/7.x/reaper735-install.exe'
-$checksum32 = 'b499dfd7bd896ffcc70a59d28d2ab7437dcabb7a86a5056deed89c867d7f9ae1'
-$url64 = 'https://reaper.fm/files/7.x/reaper735_x64-install.exe'
-$checksum64 = '148e0928ebbe703a40e25dbd83fb9da8f8cec25ffc78ccc7914576b64c1bce06'
+$url32 = 'https://reaper.fm/files/7.x/reaper736-install.exe'
+$checksum32 = '131520697e7d06ff0225d1a56a5d25d42f85f6af00cd4b58a9969f9b79c40ed3'
+$url64 = 'https://reaper.fm/files/7.x/reaper736_x64-install.exe'
+$checksum64 = 'df11baff22caa3e549859a104c2b974efec74cd38a967616c0d446d9fde2233d'
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName

--- a/reaper/update.ps1
+++ b/reaper/update.ps1
@@ -33,13 +33,19 @@ function global:au_GetLatest {
   # Get the actual download URL
   $download_base = "https://reaper.fm/"
 
-  $installer_32_regex = "reaper.*[^_64]-install.exe"
-  $installer_32_exe = $download_page.Links | ? href -match $installer_32_regex | Select-Object -First 1 -expand href
+  # Find 32-bit installer by looking for "Windows 32-bit" in the title
+  $installer_32_link = $download_page.Links | 
+  Where-Object { $_.title -match "Windows 32-bit" } | 
+  Select-Object -First 1
+  $installer_32_exe = $installer_32_link.href
   $installer_32_url = "${download_base}${installer_32_exe}"
   Write-Host "Found 32-bit installer: ${installer_32_url}"
-
-  $installer_64_regex = "reaper.*_x64-install.exe"
-  $installer_64_exe = $download_page.Links | ? href -match $installer_64_regex | Select-Object -First 1 -expand href
+  
+  # Find 64-bit installer by looking for "Windows 64-bit" in the title
+  $installer_64_link = $download_page.Links | 
+  Where-Object { $_.title -match "Windows 64-bit" } | 
+  Select-Object -First 1
+  $installer_64_exe = $installer_64_link.href
   $installer_64_url = "${download_base}${installer_64_exe}"
   Write-Host "Found 64-bit installer: ${installer_64_url}"
 


### PR DESCRIPTION
Update Reaper to 7.36

Update script to match on href title instead of regex, excludes ARM build.

Resolves #37 