### PR TITLE
Update capnproto to 1.2.0

### DIFF
--- a/capnproto/capnproto.nuspec
+++ b/capnproto/capnproto.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>capnproto</id>
     <title>Cap'n Proto</title>
-    <version>1.0.2</version>
+    <version>1.2.0</version>
     <authors>Sandstorm.io</authors>
     <owners>Kenton Varda</owners>
     <summary>Cap'n Proto compiler</summary>

--- a/capnproto/tools/chocolateyinstall.ps1
+++ b/capnproto/tools/chocolateyinstall.ps1
@@ -4,8 +4,8 @@ $ErrorActionPreference = 'Stop';
 $packageName = $env:ChocolateyPackageName
 $softwareName = 'capnproto*'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url32 = 'https://capnproto.org/capnproto-c++-win32-1.0.2.zip'
-$checksum32 = '48a69e9c10350e2c90041e7b8d7a610a43889c178b6431145da62610c9b5435a'
+$url32 = 'https://capnproto.org/capnproto-c++-win32-1.2.0.zip'
+$checksum32 = '0624f01bfa6eb08d0fa0b84cda00455448568ffe89734fd59da7b46b8729e83f'
 
 $packageArgs = @{
   packageName   = $packageName


### PR DESCRIPTION
Verified checksum by running the following command:
```
curl -sSL https://capnproto.org/capnproto-c++-win32-1.2.0.zip | sha256sum
```

This version was released on Jun 15, 2025