### PR TITLE
Update WMI namespace for Visual Studio detection

### DIFF
--- a/llvm/tools/chocolateyinstall.ps1
+++ b/llvm/tools/chocolateyinstall.ps1
@@ -35,7 +35,7 @@ Install-ChocolateyPackage @packageArgs
 # https://docs.microsoft.com/en-us/visualstudio/install/tools-for-managing-visual-studio-instances?view=vs-2019#using-windows-management-instrumentation-wmi
 # I'm open to other suggestions for detection, but can confirm that this works for both regular and admin shells for me.
 try {
-  (Get-CimInstance MSFT_VSInstance) | out-null
+  (Get-CimInstance MSFT_VSInstance -Namespace root/cimv2/vs) | out-null
 }
 catch {
   Write-Host "NOTE: Visual Studio not detected. LLVM does not provide a C/C++ standard library and may be unable to locate MSVC headers."


### PR DESCRIPTION
The `MSFT_VSInstance` class is registered in the WMI namespace `root/cimv2/vs` (as per Microsoft's documentation on tools for managing Visual Studio instances). Without specifying `-Namespace root/cimv2/vs`, PowerShell defaults to the `root/cimv2` namespace, where `MSFT_VSInstance` does not exist. This causes `Get-CimInstance MSFT_VSInstance` to always throw an `Get-CimInstance: Invalid class` error, regardless of whether Visual Studio is installed or not. As a result, the try block fails every time, the catch block executes unconditionally, and the warning message is printed even on systems where VS is present and detectable. With `-Namespace root/cimv2/vs`, the query will only fail (and show the warning) if the class truly isn't available—e.g., no VS installations or the WMI provider isn't registered properly.