### PR TITLE
Update LLVM to 22.1.8

### DIFF
--- a/llvm/llvm.nuspec
+++ b/llvm/llvm.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>llvm</id>
     <title>LLVM</title>
-    <version>22.1.7</version>
+    <version>22.1.8</version>
     <authors>LLVM team</authors>
     <owners>Bradlee Speice</owners>
     <summary>LLVM Compiler Infrastructure</summary>

--- a/llvm/tools/chocolateyinstall.ps1
+++ b/llvm/tools/chocolateyinstall.ps1
@@ -3,8 +3,8 @@ $ErrorActionPreference = 'Stop';
 
 $packageName = $env:ChocolateyPackageName
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url64 = 'https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.7/LLVM-22.1.7-win64.exe'
-$checksum64 = 'e091fcf965ce589c83c0f7c5356b2fcf3e658a8ec990bfcf79cce4389a0d1eb3'
+$url64 = 'https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.8/LLVM-22.1.8-win64.exe'
+$checksum64 = '16e5709785fef73c854646241c4a92c5cd574318d1b33c63330dd7721903e55c'
 
 $packageArgs = @{
   packageName    = $packageName


### PR DESCRIPTION
Updates the LLVM Chocolatey package from 22.1.7 to 22.1.8.

Changes:
- Update package version to 22.1.8
- Update the Windows x64 installer URL
- Update the SHA-256 checksum to `16e5709785fef73c854646241c4a92c5cd574318d1b33c63330dd7721903e55c`

Release: https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.8